### PR TITLE
Fix "Fetch Fail" error message

### DIFF
--- a/pdfjs/pdfjsPage.xaml.cs
+++ b/pdfjs/pdfjsPage.xaml.cs
@@ -46,7 +46,7 @@ namespace pdfjs
             }
 
             if (Device.RuntimePlatform == Device.Android)
-                PdfView.Source = $"file:///android_asset/pdfjs/web/viewer.html?file={WebUtility.UrlEncode(localPath)}";
+                PdfView.Source = $"file:///android_asset/pdfjs/web/viewer.html?file={"file:///" + WebUtility.UrlEncode(localPath)}";
             else
                 PdfView.Source = url;
         }


### PR DESCRIPTION
I got Fetch Failed error message.  I discovered that the path was not accepted without the "file:///" prefix when I tested in my projects today.

It could be something that android new versions stopped accepting such paths.