### PR TITLE
Enable scrolling if needed

### DIFF
--- a/Droid/Renderers/PdfWebViewRenderer.cs
+++ b/Droid/Renderers/PdfWebViewRenderer.cs
@@ -23,5 +23,12 @@ namespace pdfjs.Droid
 				Control.Settings.AllowUniversalAccessFromFileURLs = true;
 			}
 		}
+		
+		// If you want to enable scrolling in WebView uncomment the following lines.
+		//public override bool DispatchTouchEvent(MotionEvent e)
+		//{
+		//    Parent.RequestDisallowInterceptTouchEvent(true);
+		//    return base.DispatchTouchEvent(e);
+		//}
 	}
 }


### PR DESCRIPTION
Most likely people will first struck with unscrollable WebView .   The default behavior for WebView is not responding to touch gestures.  And the user will be unable to scroll through the document.  Un-commenting the lines I added will enable the user to scroll properly.